### PR TITLE
Handle WebDriver window rect requests

### DIFF
--- a/webdriver/src/handler.rs
+++ b/webdriver/src/handler.rs
@@ -119,6 +119,15 @@ impl Handler {
     pub fn new() -> Self {
         Handler {}
     }
+
+    fn compatibility_window_rect() -> WindowRectResponse {
+        WindowRectResponse {
+            x: 0,
+            y: 0,
+            width: 1280,
+            height: 720,
+        }
+    }
 }
 
 struct PortManager {
@@ -627,6 +636,12 @@ fn write_defaults(udid: &str, key: &str, key_type: &str, value: &str) {
                 let window_handles: Vec<String> = serde_json::from_str(&window_handles).expect("Failed to parse window handles");
                 info!("Window handles: {:#?}", window_handles);
                 return Ok(WebDriverResponse::Generic(ValueResponse(window_handles.into())));
+            },
+            GetWindowRect => {
+                return Ok(WebDriverResponse::WindowRect(Handler::compatibility_window_rect()));
+            },
+            SetWindowRect(_) => {
+                return Ok(WebDriverResponse::WindowRect(Handler::compatibility_window_rect()));
             },
             GetCurrentUrl => {
                 let session_id = msg.session_id.as_ref().expect("Expected a session id");

--- a/webdriver/src/handler.rs
+++ b/webdriver/src/handler.rs
@@ -121,6 +121,13 @@ impl Handler {
     }
 
     fn compatibility_window_rect() -> WindowRectResponse {
+        // Temporary compatibility response for WPT session bootstrap.
+        // Apple automation currently doesn't expose native get/set window rect endpoints,
+        // so we return a stable synthetic rect to keep shared web tests running.
+        // The longer-term fix is to plumb a real `getWindowRect` request through the
+        // Apple automation server and derive it from the active window or screen bounds,
+        // while deciding whether `setWindowRect` should be implemented or remain a
+        // documented no-op on platforms that can't resize app windows programmatically.
         WindowRectResponse {
             x: 0,
             y: 0,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds synthetic `GetWindowRect`/`SetWindowRect` handling that returns a fixed rectangle instead of delegating to the automation server, which could mask real window sizing issues or diverge from expected behavior in clients relying on actual dimensions.
> 
> **Overview**
> Provides temporary WebDriver compatibility for Apple automation by implementing `GetWindowRect` and `SetWindowRect` to return a stable synthetic `WindowRectResponse` (1280x720 at 0,0).
> 
> This unblocks WPT session bootstrap on platforms that don’t currently expose native window-rect endpoints, while documenting the intent to later wire up real window-rect support.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b9497c189d1724eceab859119942b19e2d8a6ef8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->